### PR TITLE
Validate --fanouts are ≥ 2

### DIFF
--- a/sweep_layouts.py
+++ b/sweep_layouts.py
@@ -126,6 +126,13 @@ def run_app(
 def main() -> None:
     args = parse_args()
 
+    if args.step <= 0:
+        print("ERROR: --step must be a positive integer.", file=sys.stderr)
+        sys.exit(1)
+    if any(f <= 1 for f in args.fanouts):
+        print("ERROR: all --fanouts must be >= 2.", file=sys.stderr)
+        sys.exit(1)
+
     app_path = Path(args.app_path)
     if not app_path.is_file():
         print(f"ERROR: app.py not found at {app_path}", file=sys.stderr)


### PR DESCRIPTION
Disallows invalid fan-outs like 0 or 1, which don’t make sense for a tree.